### PR TITLE
Remove async and upgrade deps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.1.0
+- Upgrade dependencies
+- Remove async api
+
 ## v1.0.0
 
 - Out of initial development stage. (https://semver.org/)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v1.1.0
+## v2.0.0
 - Upgrade dependencies
 - Remove async api
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,11 +21,7 @@ winapi = { version = "0.3.9", features = ["psapi", "processthreadsapi"] }
 [target.'cfg(target_os = "linux")'.dependencies]
 procfs = "0.14.1"
 libc = "0.2.136"
-tokio = { version = "1.21.2", features = ["fs"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 darwin-libproc = "0.2.0"
 libc = "0.2.136"
-
-[dev-dependencies]
-tokio = { version = "1.21.2", features = ["rt-multi-thread", "macros"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "simple-process-stats"
 description = "Get memory usage and CPU time on Linux and Windows"
 license = "MIT"
-version = "1.0.0"
+version = "1.1.0"
 keywords = ["process", "cpu", "memory"]
 categories = ["api-bindings", "asynchronous", "os"]
 repository = "https://github.com/robotty/simple-process-stats"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,19 +13,19 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-thiserror = "1.0.20"
+thiserror = "1.0.37"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 winapi = { version = "0.3.9", features = ["psapi", "processthreadsapi"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
-procfs = "0.9.0"
-libc = "0.2.72"
-tokio = { version = "1.0.0", features = ["fs"] }
+procfs = "0.14.1"
+libc = "0.2.136"
+tokio = { version = "1.21.2", features = ["fs"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 darwin-libproc = "0.2.0"
-libc = "0.2.72"
+libc = "0.2.136"
 
 [dev-dependencies]
-tokio = { version = "1.0.0", features = ["rt-multi-thread", "macros"] }
+tokio = { version = "1.21.2", features = ["rt-multi-thread", "macros"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,14 +4,12 @@
 //! A small library to get memory usage and elapsed CPU time.
 //!
 //! * Supports Windows, Linux and macOS.
-//! * Async interface, uses `tokio::fs` for file operations
 //!
 //! ```rust
 //! use simple_process_stats::ProcessStats;
 //!
-//! # #[tokio::main]
-//! # async fn main() {
-//! let process_stats = ProcessStats::get().await.expect("could not get stats for running process");
+//! # fn main() {
+//! let process_stats = ProcessStats::get().expect("could not get stats for running process");
 //! println!("{:?}", process_stats);
 //! // ProcessStats {
 //! //     cpu_time_user: 421.875ms,
@@ -52,19 +50,19 @@ pub struct ProcessStats {
 impl ProcessStats {
     /// Get the statistics using the OS-specific method.
     #[cfg(target_os = "windows")]
-    pub async fn get() -> Result<ProcessStats, Error> {
+    pub fn get() -> Result<ProcessStats, Error> {
         windows::get_info()
     }
 
     /// Get the statistics using the OS-specific method.
     #[cfg(target_os = "linux")]
-    pub async fn get() -> Result<ProcessStats, Error> {
-        linux::get_info().await
+    pub fn get() -> Result<ProcessStats, Error> {
+        linux::get_info()
     }
 
     /// Get the statistics using the OS-specific method.
     #[cfg(target_os = "macos")]
-    pub async fn get() -> Result<ProcessStats, Error> {
+    pub fn get() -> Result<ProcessStats, Error> {
         macos::get_info()
     }
 }

--- a/src/linux.rs
+++ b/src/linux.rs
@@ -4,13 +4,12 @@ use std::io::Cursor;
 use std::path::Path;
 use std::time::Duration;
 
-pub async fn get_info() -> Result<ProcessStats, Error> {
+pub fn get_info() -> Result<ProcessStats, Error> {
     let bytes_per_page = procfs::page_size().map_err(Error::SystemCall)?;
     let ticks_per_second = procfs::ticks_per_second().map_err(Error::SystemCall)?;
 
     let path = Path::new("/proc/self/stat");
-    let file_contents = tokio::fs::read(path)
-        .await
+    let file_contents = std::fs::read(path)
         .map_err(|e| Error::FileRead(path.to_path_buf(), e))?;
 
     let readable_string = Cursor::new(file_contents);

--- a/src/linux.rs
+++ b/src/linux.rs
@@ -9,8 +9,7 @@ pub fn get_info() -> Result<ProcessStats, Error> {
     let ticks_per_second = procfs::ticks_per_second().map_err(Error::SystemCall)?;
 
     let path = Path::new("/proc/self/stat");
-    let file_contents = std::fs::read(path)
-        .map_err(|e| Error::FileRead(path.to_path_buf(), e))?;
+    let file_contents = std::fs::read(path).map_err(|e| Error::FileRead(path.to_path_buf(), e))?;
 
     let readable_string = Cursor::new(file_contents);
     let stat_file =
@@ -31,8 +30,8 @@ pub fn get_info() -> Result<ProcessStats, Error> {
 pub mod tests {
     use crate::linux;
 
-    #[tokio::test]
-    pub async fn test_no_error() {
+    #[test]
+    pub fn test_no_error() {
         #[no_mangle]
         fn spin_for_a_bit() {
             let mut _a = 0;
@@ -44,6 +43,6 @@ pub mod tests {
         // to get some nonzero number for cpu_time_user
         spin_for_a_bit();
 
-        dbg!(linux::get_info().await.unwrap());
+        dbg!(linux::get_info().unwrap());
     }
 }


### PR DESCRIPTION
I agree with #19 the async dependency is a little annoying. 

This PR removes the async dependency and ugprades dependencies. 

Feel free to close if you prefer to maintain the async dep.