### PR TITLE
macos: convert CPU times to Duration properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unversioned
 - Major: Replaced async api with synchronous API. (#20, #22)
+- macOS: apply timebase information to CPU times. (#21)
 
 ## v1.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unversioned
 - Major: Replaced async api with synchronous API. (#20, #22)
-- macOS: apply timebase information to CPU times. (#21)
+- macOS: apply timebase information to CPU times. (#21, #25)
 
 ## v1.0.0
 

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -4,12 +4,37 @@ use std::time::Duration;
 pub fn get_info() -> Result<ProcessStats, Error> {
     let pid = unsafe { libc::getpid() };
     let proc_info = darwin_libproc::task_info(pid).map_err(Error::SystemCall)?;
+    let timebase_info = mach_timebase_info::get();
 
     Ok(ProcessStats {
         memory_usage_bytes: proc_info.pti_resident_size,
-        cpu_time_user: Duration::from_nanos(proc_info.pti_total_user),
-        cpu_time_kernel: Duration::from_nanos(proc_info.pti_total_system),
+        cpu_time_user: timebase_info.mach_time_to_duration(proc_info.pti_total_user),
+        cpu_time_kernel: timebase_info.mach_time_to_duration(proc_info.pti_total_system),
     })
+}
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+struct mach_timebase_info {
+    pub numer: u32,
+    pub denom: u32,
+}
+
+impl mach_timebase_info {
+    pub fn get() -> Self {
+        extern "C" {
+            fn mach_timebase_info(info: *mut mach_timebase_info) -> libc::c_int;
+        }
+        let mut info = mach_timebase_info { numer: 0, denom: 0 };
+        unsafe {
+            mach_timebase_info(&mut info);
+        }
+        info
+    }
+
+    pub fn mach_time_to_duration(self, time: u64) -> Duration {
+        Duration::from_nanos(time * self.numer as u64 / self.denom as u64)
+    }
 }
 
 #[cfg(test)]
@@ -30,5 +55,13 @@ pub mod tests {
         spin_for_a_bit();
 
         dbg!(macos::get_info().unwrap());
+    }
+
+    #[test]
+    pub fn test_valid_timebase_info() {
+        let timebase_info = super::mach_timebase_info::get();
+        // this should be guaranteed by the kernel
+        assert_ne!(timebase_info.numer, 0);
+        assert_ne!(timebase_info.denom, 0);
     }
 }


### PR DESCRIPTION
Scale CPU time values according to mach_timebase_info (#21).

Caching the result of the extern call should not be necessary, it is already cached in userspace (source: https://github.com/apple/darwin-xnu/blob/main/libsyscall/wrappers/mach_timebase_info.c).

Pull request checklist:

- [x] `CHANGELOG.md` was updated
